### PR TITLE
source map 구현

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) Hantry
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,18 @@
 {
+  "name": "hantry-webpack",
   "version": "0.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "hantry_webpack_plugin",
+      "name": "hantry-webpack",
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
         "axios": "^0.27.2",
-        "node-fetch": "^3.2.6"
+        "fs": "^0.0.1-security",
+        "node-fetch": "^3.2.6",
+        "webpack-sources": "^3.2.3"
       }
     },
     "node_modules/asynckit": {
@@ -118,6 +121,11 @@
         "node": ">=12.20.0"
       }
     },
+    "node_modules/fs": {
+      "version": "0.0.1-security",
+      "resolved": "https://registry.npmjs.org/fs/-/fs-0.0.1-security.tgz",
+      "integrity": "sha512-3XY9e1pP0CVEUCdj5BmfIZxRBTSDycnbqhIOGec9QYtmVH2fbLpj86CFWkrNOkt/Fvty4KZG5lTglL9j/gJ87w=="
+    },
     "node_modules/mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
@@ -178,6 +186,14 @@
       "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/webpack-sources": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
+      "integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
+      "engines": {
+        "node": ">=10.13.0"
       }
     }
   },
@@ -246,6 +262,11 @@
         "fetch-blob": "^3.1.2"
       }
     },
+    "fs": {
+      "version": "0.0.1-security",
+      "resolved": "https://registry.npmjs.org/fs/-/fs-0.0.1-security.tgz",
+      "integrity": "sha512-3XY9e1pP0CVEUCdj5BmfIZxRBTSDycnbqhIOGec9QYtmVH2fbLpj86CFWkrNOkt/Fvty4KZG5lTglL9j/gJ87w=="
+    },
     "mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
@@ -278,6 +299,11 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
       "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q=="
+    },
+    "webpack-sources": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
+      "integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,5 +16,15 @@
   "dependencies": {
     "axios": "^0.27.2",
     "node-fetch": "^3.2.6"
-  }
+  },
+  "name": "hantry-webpack",
+  "devDependencies": {},
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/hkh0105/Hantry-WebPack.git"
+  },
+  "bugs": {
+    "url": "https://github.com/hkh0105/Hantry-WebPack/issues"
+  },
+  "homepage": "https://github.com/hkh0105/Hantry-WebPack#readme"
 }

--- a/package.json
+++ b/package.json
@@ -15,10 +15,11 @@
   "license": "MIT",
   "dependencies": {
     "axios": "^0.27.2",
-    "node-fetch": "^3.2.6"
+    "fs": "^0.0.1-security",
+    "node-fetch": "^3.2.6",
+    "webpack-sources": "^3.2.3"
   },
   "name": "hantry-webpack",
-  "devDependencies": {},
   "repository": {
     "type": "git",
     "url": "git+https://github.com/hkh0105/Hantry-WebPack.git"

--- a/src/hantryPlugin.js
+++ b/src/hantryPlugin.js
@@ -1,0 +1,78 @@
+const axios = require("axios");
+
+class HantryPlugin {
+  constructor(options, name, dsn) {
+    this.options = options;
+    this.name = name;
+    this.serverUrl = `http://localhost:8000/users`;
+    this.dsn = dsn;
+  }
+
+  apply(compiler) {
+    compiler.hooks.emit.tapAsync(
+      "HantryPlugin",
+      async (compilation, callback) => {
+        if (!compilation.errors.length) {
+          return callback();
+        }
+
+        const errorCollection = compilation.errors.map(err => {
+          let targetError = err.error.stack ? err.error : err;
+          return {
+            name: targetError.name,
+            message: targetError.message.split("\n")[0],
+            stack: targetError.stack,
+            lineno: targetError.loc && targetError.loc.line,
+            colno: targetError.loc && targetError.loc.column,
+            filename: err.module.resource,
+            duplicate_count: 1,
+            created_at: new Date(),
+          };
+        });
+
+        const errorList = { errorInfo: errorCollection };
+
+        await this.sendErrorApi(this.dsn, errorList);
+        callback();
+      },
+    );
+  }
+
+  apply(compiler) {
+    compiler.hooks.afterEmit.tapAsync("HantryPlugin", async compilation => {
+      console.log(this.name);
+      if (compilation.emittedAssets.has(`${this.name}.js.map`)) {
+        const sourceMap = fs.readFileSync(
+          `./dist/${this.name}.js.map`,
+          "utf-8",
+        );
+        const source = fs.readFileSync(`./dist/${this.name}.js`, "utf-8");
+        sendSourceMapApi(source, source, this.dsn);
+      }
+    });
+  }
+
+  sendErrorApi(dsn, errorList) {
+    return axios
+      .post(`${this.serverUrl}/project/${dsn}/error`, errorList)
+      .then(res => {
+        console.log(res.data);
+        console.log("Hantry: error recorded");
+      });
+  }
+
+  sendSourceMapApi(sourceMap, source, dsn) {
+    console.log(sourceMap, source);
+    return axios
+      .post(`${this.serverUrl}/project/${dsn}/sourceMap`, {
+        sourceMap,
+        source,
+      })
+      .then(res => {
+        console.log(res.data);
+        console.log("Hantry: error recorded");
+      });
+  }
+}
+
+module.exports = HantryPlugin;

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,25 @@
+const fs = require("fs");
+const path = require("path");
+
+function getSourceMap(compiler) {
+  if (!compiler.hooks || !compiler.hooks.make) {
+    return;
+  }
+
+  compiler.hooks.done.tapAsync("HantryPlugin", (stats, callback) => {
+    const sourceMapFileName = stats.compilation.outputOptions.sourceMapFilename;
+    const bundledSourceFileName = stats.compilation.outputOptions.filename;
+    const sourceMap = fs.readFileSync(
+      path.join(stats.compilation.outputOptions.path, sourceMapFileName),
+      "utf8",
+    );
+    const bundledSource = fs.readFileSync(
+      path.join(stats.compilation.outputOptions.path, bundledSourceFileName),
+      "utf8",
+    );
+
+    return { sourceMap, bundledSource };
+  });
+}
+
+module.exports = { getSourceMap };


### PR DESCRIPTION
## 개요
유저가 소스맵을 Webpack 설정으로 만들면,
그걸 감지하고 서버로 보내는 로직 구현

## PR Type

- [ ] 버그 픽스 / 사소한 변경 (앱 실행에 영향을 주지 않는 변경을 의미합니다.)

- [x] 기능 구현

- [ ] 중요한 변경 사항 (앱의 기능이 변화하거나 앱 실행에 직접적인 영향을 주는 수준의 변경을 의미합니다.)

- [ ] 변경 사항으로 인해 문서를 업데이트 해야 합니다.


## 주요 구현점 / 변경점

컴파일이 완료되었을때의 훅을 한 후, stats 객체에서 소스맵과 번들된 소스의 정보를 받고. fs로 읽은후 서버로 보내는 로직입니다.


```js
compiler.hooks.done.tapAsync("HantryPlugin", (stats, callback) => {
    const sourceMapFileName = stats.compilation.outputOptions.sourceMapFilename;
    const bundledSourceFileName = stats.compilation.outputOptions.filename;
    sourceMap = fs.readFileSync(
      path.join(stats.compilation.outputOptions.path, sourceMapFileName),
      "utf8",
    );
    bundledSource = fs.readFileSync(
      path.join(stats.compilation.outputOptions.path, bundledSourceFileName),
      "utf8",
    );
  });
  return { sourceMap, bundledSource };
```

## 코드 리뷰시 주의사항

- 서버에 저장되는것을 확인 했습니다!
